### PR TITLE
Add build directory for compose worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - grouparoo_backend
 
   grouparoo-worker:
+    build: ./
     image: grouparoo/local-image
     restart: always
     environment:


### PR DESCRIPTION
Without this, following the docker compose instructions in the readme will cause an error when first attempted.

Fixes #10 